### PR TITLE
Add DAT support for MATLAB client

### DIFF
--- a/getcancerstudies.m
+++ b/getcancerstudies.m
@@ -9,19 +9,19 @@ function cancerStudies = getcancerstudies(cgdsURL, varargin)
 %
 %    Field names follow column names as returned by the web API.
 %
-%    A = GETcancerStudies(cgdsURL, 'silent')
-%    runs the function in non-verbose mode, supressing status and warning
-%    messages from the cBio CGDS web API. Any string or numerical
-%    (e.g. 'non-verbose' or 0) will have this effect. Error messages are
-%    always printed, as these indicate an unrecoverable problem.
+%    A = GETCANCERSTUDIES(cgdsURL, 'verbose', [true | false], 'token', '<some token string>')
+%      - set 'verbose' to false to run in silent mode or true to run in verbose mode. Default is false.
+%      - set token to a valid token string for private portals.
 %
 %    See also getgeneticprofiles, getcaselists, getprofiledata,
 %    getclinicaldata.
 
-verbose = isempty(varargin);
+% parse input arguments
+[verbose, token] = cgdsparser(varargin{:});
+
 if ~strcmp(cgdsURL(end), '/') cgdsURL(end + 1) = '/'; end
 
-cells  = urlgetcells([cgdsURL 'webservice.do?cmd=getCancerStudies'], verbose);
+cells  = urlgetcells([cgdsURL 'webservice.do?cmd=getCancerStudies'], verbose, token);
 
 cancerStudies.cancerTypeId = cells(2:end, 1);
 cancerStudies.name = cells(2:end, 2);

--- a/getcaselists.m
+++ b/getcaselists.m
@@ -13,19 +13,17 @@ function caseLists = getcaselists(cgdsURL, cancerTypeId, varargin)
 %
 %    Field names follow column names as returned by the web API.
 %
-%    A = GETCASELISTS(cgdsURL, cancerTypeId, 'silent')
-%    runs the function in non-verbose mode, supressing status and warning
-%    messages from the cBio CGDS web API. Any string or numerical
-%    (e.g. 'non-verbose' or 0) will have this effect. Error messages are
-%    always printed, as these indicate an unrecoverable problem.
+%    A = GETCASELISTS(cgdsURL, cancerTypeId, 'verbose', [true | false], 'token', '<some token string>')
+%      - set 'verbose' to false to run in silent mode or true to run in verbose mode. Default is false.
+%      - set token to a valid token string for private portals
 %
 %    See also getcancertypes, getgeneticprofiles, getprofiledata,
 %    getclinicaldata.
 
-verbose = isempty(varargin);
+[verbose, token] = cgdsparser(varargin{:});
 if ~strcmp(cgdsURL(end), '/') cgdsURL(end + 1) = '/'; end
 
-cells  = urlgetcells([cgdsURL 'webservice.do?cmd=getCaseLists&cancer_type_id=' cancerTypeId], verbose);
+cells  = urlgetcells([cgdsURL 'webservice.do?cmd=getCaseLists&cancer_type_id=' cancerTypeId], verbose, token);
 
 caseLists.caseListId = cells(2:end, 1);
 caseLists.caseListName = cells(2:end, 2);

--- a/getclinicaldata.m
+++ b/getclinicaldata.m
@@ -13,19 +13,17 @@ function clinicalData = getclinicaldata(cgdsURL, caseListId, varargin)
 %    is given as strings. Use str2double() to convert to numeric format
 %    when appropriate.
 %
-%    A = getclinicaldata(cgdsURL, caseListId, 'silent')
-%    runs the function in non-verbose mode, supressing status and warning
-%    messages from the cBio CGDS web API. Any string or numerical
-%    (e.g. 'non-verbose' or 0) will have this effect. Error messages are
-%    always printed, as these indicate an unrecoverable problem.
+%    A = GETCLINICALDATA(cgdsURL, caseListId, 'verbose', [true | false], 'token', '<some token string>')
+%      - set 'verbose' to false to run in silent mode or true to run in verbose mode. Default is false.
+%      - set token to a valid token string for private portals
 %
 %    See also getcancertypes, getgeneticprofiles, getcaselists,
 %    getprofiledata.
 
-verbose = isempty(varargin);
+[verbose, token] = cgdsparser(varargin{:});
 if ~strcmp(cgdsURL(end), '/') cgdsURL(end + 1) = '/'; end
 
-cells  = urlgetcells([cgdsURL 'webservice.do?cmd=getClinicalData&case_set_id=' caseListId], verbose);
+cells  = urlgetcells([cgdsURL 'webservice.do?cmd=getClinicalData&case_set_id=' caseListId], verbose, token);
 
 clinicalData.caseId = cells(2:end, 1);
 clinicalData.clinVariable = cells(1, 2:end)';

--- a/getgeneticprofiles.m
+++ b/getgeneticprofiles.m
@@ -11,19 +11,17 @@ function geneticProfiles = getgeneticprofiles(cgdsURL, cancerTypeId, varargin)
 %
 %    Field names follow column names returned by the web API.
 %
-%    A = GETGENETICPROFILES(cgdsURL, cancerTypeId, 'silent')
-%    runs the function in non-verbose mode, supressing status and warning
-%    messages from the cBio CGDS web API. Any string or numerical
-%    (e.g. 'non-verbose' or 0) will have this effect. Error messages are
-%    always printed, as these indicate an unrecoverable problem.
+%    A = GETGENETICPROFILES(cgdsURL, cancerTypeId, 'verbose', [true | false], 'token', '<some token string>')
+%      - set 'verbose' to false to run in silent mode or true to run in verbose mode. Default is false.
+%      - set token to a valid token string for private portals
 %
 %    See also getcancertypes, getcaselists, getprofiledata,
 %    getclinicaldata.
 
-verbose = isempty(varargin);
+[verbose, token] = cgdsparser(varargin{:});
 if ~strcmp(cgdsURL(end), '/') cgdsURL(end + 1) = '/'; end
 
-cells  = urlgetcells([cgdsURL 'webservice.do?cmd=getGeneticProfiles&cancer_type_id=' cancerTypeId], verbose);
+cells  = urlgetcells([cgdsURL 'webservice.do?cmd=getGeneticProfiles&cancer_type_id=' cancerTypeId], verbose, token);
 
 geneticProfiles.geneticProfileId = cells(2:end, 1);
 geneticProfiles.geneticProfileName = cells(2:end, 2);

--- a/getprofiledata.m
+++ b/getprofiledata.m
@@ -24,21 +24,19 @@ function profileData = getprofiledata(cgdsURL, caseListId, geneticProfileId, gen
 %
 %    Field names follow column names as returned by the web API.
 %
-%    A = GETPROFILEDATA(cgdsURL, caseListId, geneticProfileId, geneList, toNumeric, 'silent')
-%    runs the function in non-verbose mode, supressing status and warning
-%    messages from the cBio CGDS web API. Any string or numerical
-%    (e.g. 'non-verbose' or 0) will have this effect. Error messages are
-%    always printed, as these indicate an unrecoverable problem.
+%    A = GETPROFILEDATA(cgdsURL, caseListId, geneticProfileId, geneList, toNumeric, 'verbose', [true | false], 'token', '<some token string>')
+%      - set 'verbose' to false to run in silent mode or true to run in verbose mode. Default is false.
+%      - set token to a valid token string for private portals
 %
 %    See also getcancertypes, getgeneticprofiles, getcaselists,
 %    getclinicaldata.
 
-verbose = isempty(varargin);
+[verbose, token] = cgdsparser(varargin{:});
 if ~strcmp(cgdsURL(end), '/') cgdsURL(end + 1) = '/'; end
 
 cells  = urlgetcells([cgdsURL 'webservice.do?cmd=getProfileData&case_set_id=' caseListId ...
                       '&genetic_profile_id=' cellarraytostr(geneticProfileId) ...
-                      '&gene_list=' cellarraytostr(geneList)], verbose);
+                      '&gene_list=' cellarraytostr(geneList)], verbose, token);
 
 % determine format
 if strcmp(cells(1,1), 'GENE_ID')

--- a/private/cgdsparser.m
+++ b/private/cgdsparser.m
@@ -1,0 +1,14 @@
+function [verbose, token] = cgdsparser(varargin)
+% Parses varargin and returns values for 'verbose' and 'token'.
+% Output:
+%   - verbose = [true | false], optional argument. Default is false.
+%   - token = data authentication token. Default is empty string.
+
+p = inputParser;
+addOptional(p, 'verbose', false);
+addOptional(p, 'token', '');
+parse(p,varargin{:})
+verbose = p.Results.verbose;
+token = p.Results.token;
+end
+

--- a/private/urlgetcells.m
+++ b/private/urlgetcells.m
@@ -1,14 +1,19 @@
-function cells = urlgetcells(url, verbose)
+function cells = urlgetcells(url, verbose, token)
 % this function is only used internally by the CGDS matlab toolbox
 % returns a 2D cell array where each cell contains a tab-delimited 'cell'
 % from the server output
 
 % decrease if out of memory errors are encountered
 nPrealloc = 10000;
+if ~isempty(token)
+    headerFields = {'Authorization', ['Bearer ', token]};
+    options = weboptions('HeaderFields', headerFields, 'Timeout', 300); %timeout value is in seconds
+    S = webread(url, options);
+else
+    S = webread(url);
+end
 
-S = urlread(url);
-
-rows = textscan(S, '%s', 'delimiter', '\n', 'BufSize', 65535);
+rows = textscan(S, '%s', 'delimiter', '\n');
 rows = rows{1};
 
 cells = cell(nPrealloc, 1);
@@ -25,7 +30,7 @@ for i = 1:length(rows)
     else
         % this row contains data/header rather than status/warnings/errors    
         n = n + 1;
-        thisCells = textscan(thisRow, '%s', 'delimiter', '\t', 'BufSize', 65535);
+        thisCells = textscan(thisRow, '%s', 'delimiter', '\t');
         thisCells = thisCells{1};
         cells(n, 1:length(thisCells)) = thisCells;
     end


### PR DESCRIPTION
- Added command line option parser
- Use `webread` instead of `urlread` so that we can pass  http headers to api

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>